### PR TITLE
Add super basic admin page with facebook admin auth, list all users currently in DB

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,24 @@
+class AdminController < ActionController::Base
+  protect_from_forgery with: :exception
+  before_action :authenticate_user!
+
+  def index
+    if not current_user.present?
+      render status: :forbidden
+      return
+    end
+
+    admin_uids = [
+      "10157774150465553" # Josh G
+    ]
+
+    if not admin_uids.include? current_user.uid
+      render status: :forbidden
+      return
+    end
+
+    @users = User.order(:id).take(100000)
+
+    render layout: "application"
+  end
+end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,0 +1,29 @@
+<h1>Admin - user list</h1>
+
+
+<table class="table">
+  <thead>
+    <tr>
+      <td>#</td>
+      <td>Email</td>
+      <td>Created</td>
+      <td>Zip</td>
+      <td>Supported</td>
+      <td>Desired</td>
+      <td>Background</td>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.id %></td>
+        <td><%= user.email %></td>
+        <td><%= user.created_at %></td>
+        <td><%= user.zip %></td>
+        <td><%= user.supported %></td>
+        <td><%= user.desired %></td>
+        <td><%= user.background %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,8 @@ Rails.application.routes.draw do
   root to: 'responses#index'
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
   resources :responses
+
+  resources :admin do
+    root to: 'admin#index'
+  end
 end


### PR DESCRIPTION
Baby steps towards #6.

Instead of hard-coding the list of FB UIDs, we could also put these into env vars. They're not really sensitive, but it's a moderate privacy concern, maybe. 