### PR TITLE
Prefer pairings with Clinton supporters who want to talk to anyone

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,6 +143,15 @@ class User < ActiveRecord::Base
       .where(supported: desired_supported)
       .where.not(id: self.id)
 
+    # If we're a third-party supporter and willing to talk to anyone, prefer
+    # pairing with a Clinton supporter willing to talk to anyone.
+    if [:stein, :johnson, :other].include? supported.to_sym and desired.to_sym == :anyone
+      clinton_supporter_scope = scope.where(supported: 'clinton', desired: 'anyone')
+      if clinton_supporter_scope.exists? # There is at least one relevant Clinton supporter
+        scope = clinton_supporter_scope
+      end
+    end
+
     # Combinations of keywords
     words = key_words
     while words.present?


### PR DESCRIPTION
Implemented #37. If there is a relevant Clinton supporter for a third-party voter, that person is preferred even if they don't live nearby and have nothing in common. The keyword relevance and proximity preferences are still enforced between different Clinton supporters.